### PR TITLE
Change OPENFORTIVPN_VERSION to a build-arg and update to v1.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine as builder
 
-ENV OPENFORTIVPN_VERSION=v1.7.1
+ARG OPENFORTIVPN_VERSION=v1.13.3
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
Hello,

Thank you for your work building this container setup.

I'm proposing using a build-arg instead of a regular environment variable in the Dockerfile, which would allow users to specify `--build-arg` to build their required version of openfortivpn without having to edit the Dockerfile.

This PR also sets the openfortivpn version to the latest version.